### PR TITLE
Fix Syntax error on ACF

### DIFF
--- a/models/JVMUtil.cfc
+++ b/models/JVMUtil.cfc
@@ -27,9 +27,9 @@ component singleton {
 	 *
 	 * @return The absolute path to the generated heap dump
 	 */
-	string function generateHeapDump( directoryPath ){
+	string function generateHeapDump( directoryPath = getTempDirectory() ){
 		// Create it if it doesn't exist
-		if ( !directoryExists( arguments.directoryPath = getTempDirectory() ) ) {
+		if ( !directoryExists( arguments.directoryPath ) ) {
 			directoryCreate( arguments.directoryPath );
 		}
 


### PR DESCRIPTION
## Type of change

Bug Fix

# Description

Code was throwing DIRECTORYEXISTS Parameter validation error:

Parameter validation error for the DIRECTORYEXISTS function.The Valid Parameter for function DIRECTORYEXISTS are [path]
